### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sparkoo/racemate-web/security/code-scanning/1](https://github.com/sparkoo/racemate-web/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for accessing the repository's code, and no write permissions are needed. Additionally, we will include `actions: read` to allow artifact-related actions like uploading build artifacts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
