### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,8 +2,9 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
-  push:
     branches:
       - master
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/sparkoo/racemate-web/security/code-scanning/2](https://github.com/sparkoo/racemate-web/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum permissions required. Based on the workflow's operations, it primarily interacts with repository contents and uses the `GITHUB_TOKEN` for deployment. Therefore, the `contents: read` permission is sufficient for most steps, and additional permissions (if any) will be added only if required.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
